### PR TITLE
DM-5370: Create `lsst_ci` package as a continuous integration build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # lsst_ci - A build target for LSST DM Continous Integration
 
-Builds targets key to supported cameras.
+Build target package to ensure that supported cameras pass their tests:
 
-Intended for quick (minutes scale) integration testing.
+```
+obs_cfht
+obs_decam
+obs_subaru
+obs_lsstSim
+testdata_cfht
+testdata_decam
+testdata_subaru
+```
 
-However, it does depend on 10-20 GB of data repositories.  For running on Jenkins or similar build system, this is a one-time cost that should be fine, but it may be annoying to an individual developer who would like to run this package.
+Intended for quick (minutes scale) integration testing.  Currently the test is just that this package successfully builds, which just means that its dependencies (`obs_cfht`, `obs_decam`, `obs_subaru`, and `obs_lsstSim`) successfully build with their full tests as enabled by the `testdata_cfht`, `testdata_decam`, and `testdata_subaru` packages.
+
+The `testdata_*` packages total approximately 3 GB of data repositories.  For running on Jenkins or similar build system, this is a one-time cost that should be fine, but it may be annoying to an individual developer who would like to run this package.

--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,3 @@
+# -*- python -*-
+from lsst.sconsUtils import scripts
+scripts.BasicSConstruct("lsst_ci")

--- a/ups/lsst_ci.build
+++ b/ups/lsst_ci.build
@@ -1,0 +1,2 @@
+@LSST BUILD@ &&
+build_lsst @PRODUCT@ @VERSION@ @REPOVERSION@

--- a/ups/lsst_ci.cfg
+++ b/ups/lsst_ci.cfg
@@ -1,0 +1,13 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = dict(
+)
+
+config = lsst.sconsUtils.Configuration(
+    __file__,
+    libs=[],
+    hasDoxygenInclude=False,
+    hasSwigFiles=False,
+)

--- a/ups/lsst_ci.table
+++ b/ups/lsst_ci.table
@@ -8,3 +8,5 @@ setupRequired(testdata_decam)
 setupRequired(obs_subaru)
 setupRequired(obs_cfht)
 setupRequired(obs_decam)
+
+setupRequired(obs_lsstSim)

--- a/ups/lsst_ci.table
+++ b/ups/lsst_ci.table
@@ -1,0 +1,10 @@
+setupRequired(lsst)
+setupRequired(lsst_apps)
+setupRequired(lsst_distrib)
+
+setupRequired(testdata_subaru)
+setupRequired(testdata_cfht)
+setupRequired(testdata_decam)
+setupRequired(obs_subaru)
+setupRequired(obs_cfht)
+setupRequired(obs_decam)

--- a/ups/lsst_ci.table
+++ b/ups/lsst_ci.table
@@ -10,3 +10,4 @@ setupRequired(obs_cfht)
 setupRequired(obs_decam)
 
 setupRequired(obs_lsstSim)
+setupRequired(obs_sdss)


### PR DESCRIPTION
Depends on `obs_cfht`, `obs_decam`, `obs_subaru`,  `obs_lsstSim`
and their testdata
`testdata_cfht`, `testdata_decam`, `testdata_subaru`
