### PR TITLE
DM-24716: Ensure that supported obs packages are set up

### DIFF
--- a/ups/lsst_ci.table
+++ b/ups/lsst_ci.table
@@ -1,17 +1,14 @@
 setupRequired(lsst_apps)
 setupRequired(lsst_distrib)
 
+# Ensure obs packages are available (should be setup by lsst_distrib)
+setupRequired(lsst_obs)
+
 setupRequired(lsst_dm_stack_demo)
 
 setupRequired(testdata_subaru)
 setupRequired(testdata_cfht)
 setupRequired(testdata_decam)
-setupRequired(obs_subaru)
-setupRequired(obs_cfht)
-setupRequired(obs_decam)
-
-setupRequired(obs_lsstSim)
-setupRequired(obs_sdss)
 
 setupRequired(validation_data_cfht)
 setupRequired(validation_data_decam)


### PR DESCRIPTION
Previously we had individual obs packages listed but that adds
extra support load and lsst_distrib already sets up obs packages.